### PR TITLE
Accept and Content-Type 

### DIFF
--- a/spec/lib/ticket_evolution/core/connection_spec.rb
+++ b/spec/lib/ticket_evolution/core/connection_spec.rb
@@ -280,31 +280,63 @@ describe TicketEvolution::Connection do
     it { should be_a Faraday::Connection }
 
     context "api version 8" do
-      let(:headers) do
-        {
-          "Accept" => "application/vnd.ticketevolution.api+json; version=#{valid_options[:version]}",
-          "X-Signature" => "8eaaqg6d4DJ2SEWkCvkdhc05dITmpNbUrcbN75UBGMA=",
-          "X-Token" => valid_options[:token],
-          "Content-Type" => "application/json"
-
-        }
+      context "POST request" do
+        let(:headers) do
+          {
+            "Accept" => "application/vnd.ticketevolution.api+json; version=#{valid_options[:version]}",
+            "X-Signature" => "6PMaU8JQ5kH4PZLl8agJrZRZqnn65UGcCUA80E2dTDg=",
+            "X-Token" => valid_options[:token],
+            "Content-Type" => "application/json"
+          }
+        end
+      
+        subject { klass.new(req_options).build_request(:POST, '/test', params) }
+      
+        its(:headers) { should == headers }
       end
-      subject { klass.new(req_options).build_request(:GET, '/test', params) }
 
-      its(:headers) { should == headers }
+      context "GET request" do
+        let(:headers) do
+          {
+            "Accept" => "application/vnd.ticketevolution.api+json; version=#{valid_options[:version]}",
+            "X-Signature" => "8eaaqg6d4DJ2SEWkCvkdhc05dITmpNbUrcbN75UBGMA=",
+            "X-Token" => valid_options[:token],
+          }
+        end
+        
+        subject { klass.new(req_options).build_request(:GET, '/test', params) }
+
+        its(:headers) { should == headers }
+      end
     end
 
     context "api version 9 or above" do
-      let(:headers) do
-        {
-          "X-Signature" => "YbwEmJL9P0hvpplEr2q2iL4Mpz+KevHUOjzgYh0ewh4=",
-          "X-Token" => valid_options[:token],
-          "Content-Type" => "application/json"
-        }
-      end
-      subject { klass.new(req_options.merge(:version => 9)).build_request(:GET, '/test', params) }
+      context "POST request" do
+        let(:headers) do
+          {
+            "Accept" => "application/json",
+            "X-Signature" => "UO957hWyAXsFJD7WAepRmrWi0Gcfge5j1I66zaTKOFs=",
+            "X-Token" => valid_options[:token],
+            "Content-Type" => "application/json"
+          }
+        end
+        subject { klass.new(req_options.merge(:version => 9)).build_request(:POST, '/test', params) }
 
-      its(:headers) { should == headers }
+        its(:headers) { should == headers }
+      end
+
+      context "GET request" do
+        let(:headers) do
+          {
+            "Accept" => "application/json",
+            "X-Signature" => "YbwEmJL9P0hvpplEr2q2iL4Mpz+KevHUOjzgYh0ewh4=",
+            "X-Token" => valid_options[:token],
+          }
+        end
+        subject { klass.new(req_options.merge(:version => 9)).build_request(:GET, '/test', params) }
+
+        its(:headers) { should == headers }
+      end
     end
   end
 end


### PR DESCRIPTION
Setting the Accept header to application/json for API version > 8
Removing the Content-Type for GET requests

closes #34
