### PR TITLE
Prevent Digest::Digest deprecation warning.

### DIFF
--- a/lib/ticket_evolution/core/connection.rb
+++ b/lib/ticket_evolution/core/connection.rb
@@ -75,7 +75,7 @@ module TicketEvolution
       d = "#{method} #{process_params(method, path, content).gsub(TicketEvolution::Connection.protocol+'://', '').gsub(/\:\d{2,5}\//, '/')}"
       Base64.encode64(
         OpenSSL::HMAC.digest(
-          OpenSSL::Digest::Digest.new('sha256'),
+          OpenSSL::Digest.new('sha256'),
           @config[:secret],
           d
       )).chomp


### PR DESCRIPTION
OpenSSL::Digest::Digest is deprecated (see https://github.com/ruby/ruby/pull/446).

The warning (`Digest::Digest is deprecated; use Digest`) is appearing on every API call. Here's a discussion on Stack Overflow:
http://stackoverflow.com/questions/21184960/ruby-digestdigest-is-deprecated-use-digest